### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Wrapper for libwebp in C#. The most complete wrapper in pure managed C#.
 
 Exposes Simple Decoding and Encoding API, Advanced Decoding and Encoding API (with statistics of compression), Get version library and WebPGetFeatures (info of any WebP file). Exposed get PSNR, SSIM or LSIM distortion metrics.
 
-The wrapper is in safe managed code in one class. No need for external dll except libwebp_x86.dll(included v0.4.4) and libwebp_x64.dll (included v1.2.1). The wrapper works in 32, 64 bit or ANY (auto swith to the appropriate library).
+The wrapper is in safe managed code in one class. No need for external dll except libwebp_x86.dll (included v0.4.4) and libwebp_x64.dll (included v1.2.1). The wrapper works in 32, 64 bit or ANY (auto swith to the appropriate library).
 
 The code is commented and includes simple examples for using the wrapper.
 
@@ -137,4 +137,4 @@ MessageBox.Show("Red: " + result[0] + dB\n" +
 
 
 ## Thanks to jzern@google.com
-Without their help this wapper would not have been possible.
+Without their help this wrapper would not have been possible.


### PR DESCRIPTION
Btw, there are typos in the project's About: w(r)apper [2x], "with statistics of compression"
But there seems to be a limit of 350 characters now.